### PR TITLE
Trim transparency from histogram colors

### DIFF
--- a/lib/image_processor/impl.ex
+++ b/lib/image_processor/impl.ex
@@ -69,7 +69,7 @@ defmodule ImageProcessor.Impl do
   defp get_hex_colors(hist) do
     colors =
       hist
-      |> Enum.map(fn %{"hex" => hex} -> hex end)
+      |> Enum.map(fn %{"hex" => hex} -> hex |> String.slice(0..6) end)
 
     colors |> make_eight_colors
   end


### PR DESCRIPTION
On the deployed machine (Ubuntu with ImageMagick 6.9.7), the themes
generated included the alpha channel.  These strings did *not* trigger
slack's auto theme button formatting.

The fix is simply to trim the theme to 6 characters before spitting
things out.